### PR TITLE
Add intial CB API team tests

### DIFF
--- a/client_apis/python/src/cbapi/cbapi.py
+++ b/client_apis/python/src/cbapi/cbapi.py
@@ -326,6 +326,27 @@ class CbApi(object):
         r = requests.put(url, headers=self.token_header, verify=self.ssl_verify, data = json.dumps(request))
         r.raise_for_status()
 
+    def server_enum(self):
+        """
+        Get all server nodes in the environment
+        """
+        url = "%s/api/server" % self.server
+
+        r = requests.get(url, headers=self.token_header, verify=self.ssl_verify)
+        r.raise_for_status()
+        return r.json()
+
+    def server_modify(self, server_id, server):
+        """
+        Update a server
+        :param server_id: The ID of the server to update
+        :param server: The modified server object
+        """
+        url = "%s/api/server/%s" % (self.server, server_id)
+
+        r = requests.put(url, headers=self.token_header, data=json.dumps(server), verify=self.ssl_verify)
+        r.raise_for_status()
+        return
 
     def watchlist(self, id=None):
         '''

--- a/client_apis/python/src/cbapi/cbapi.py
+++ b/client_apis/python/src/cbapi/cbapi.py
@@ -923,6 +923,21 @@ class CbApi(object):
         r.raise_for_status()
         
         #return r.json()
+
+    def team_modify(self, id, team):
+        """
+        Updates a team
+        :param id: The ID of the team to modify
+        :param team: The modified team object
+        :return: a JSON object indicating a successful result
+        """
+
+        url = "%s/api/team/%s" % (self.server, id)
+
+        r = requests.put(url, headers=self.token_header, verify=self.ssl_verify)
+        r.raise_for_status()
+
+        return r.json()
     
     def group_del(self, id):
         '''

--- a/client_apis/python/src/tests/integration/helpers/testdata_gen.py
+++ b/client_apis/python/src/tests/integration/helpers/testdata_gen.py
@@ -36,3 +36,13 @@ class TestDataGen:
 
         return user
 
+    @classmethod
+    def gen_team(cls):
+        uid_hex = cls.gen_uid_hex()
+
+        team = {
+            'name': 'Test Team ' + uid_hex,
+            'group_access': []
+        }
+        return team
+

--- a/client_apis/python/src/tests/integration/helpers/testdata_gen.py
+++ b/client_apis/python/src/tests/integration/helpers/testdata_gen.py
@@ -1,0 +1,38 @@
+#
+# CARBON BLACK API TEST HELPERS - testdata_gen
+# Copyright, Bit9, Inc 2015
+#
+
+"""This is a helper to generate (in-memory) test data that can be used to pass
+as argument information for various API methods
+"""
+
+import uuid
+
+class TestDataGen:
+    @staticmethod
+    def gen_uid_hex():
+        return uuid.uuid4().hex
+
+    @classmethod
+    def gen_user(cls):
+        uid_hex = cls.gen_uid_hex()
+
+        user = {
+            'username': 'testuser' + uid_hex,
+            'first_name': 'IntegrationUser_' + uid_hex,
+            'last_name': 'TestUser',
+            'email': 'integration.testuser ' + uid_hex + '@example.com',
+            'password': 'p@ssw0rd',
+            'global_admin': False,
+            'teams': []
+        }
+        return user
+
+    @classmethod
+    def gen_global_admin(cls):
+        user = cls.gen_user()
+        user['global_admin'] = True
+
+        return user
+

--- a/client_apis/python/src/tests/integration/server_test.py
+++ b/client_apis/python/src/tests/integration/server_test.py
@@ -1,0 +1,108 @@
+#
+# CARBON BLACK API TESTS - server
+# Copyright, Bit9, Inc 2015
+#
+
+""" These tests require CarbonBlack Enterprise Server to be installed.
+    You can run this script by passing the server URL and user API token
+    as parameters.
+"""
+
+import unittest
+import sys
+import os
+import requests
+from datetime import datetime
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")))
+
+from cbapi.cbapi import CbApi
+
+cb = None
+
+
+class CbApiServerTest(unittest.TestCase):
+
+    def test_get_servers(self):
+        servers = cb.server_enum()
+        self.assertIsNotNone(servers)
+        self.assertGreater(len(servers), 0)
+        return
+
+    def test_modify_server(self):
+        servers = cb.server_enum()
+        self.assertIsNotNone(servers)
+        self.assertGreater(len(servers), 0)
+
+        server = servers[0]
+        old_hostname = server["hostname"]
+        new_hostname = old_hostname + "test"
+        server["hostname"] = new_hostname
+
+        cb.server_modify(server["node_id"], server)
+
+        mod_servers = cb.server_enum()
+        self.assertIsNotNone(mod_servers)
+        self.assertGreater(len(mod_servers), 0)
+        self.assertEqual(mod_servers[0]["hostname"], new_hostname)
+
+        server["hostname"] = old_hostname
+
+        cb.server_modify(server["node_id"], server)
+
+        servers = cb.server_enum()
+        self.assertIsNotNone(servers)
+        self.assertGreater(len(servers), 0)
+        self.assertEqual(servers[0]["hostname"], old_hostname)
+        return
+
+    def test_modify_server_invalid(self):
+
+        servers = cb.server_enum()
+        self.assertIsNotNone(servers)
+        self.assertGreater(len(servers), 0)
+
+        server = servers[0]
+
+        with self.assertRaises(requests.HTTPError):
+            cb.server_modify("bad_id", server)
+
+        servers = cb.server_enum()
+        self.assertIsNotNone(servers)
+        self.assertGreater(len(servers), 0)
+
+        old_address = server["address"]
+        server["address"] = "baddress"
+
+        update_failed = False
+        try:
+            cb.server_modify(server["node_id"], server)
+        except:
+            update_failed = True
+
+        if not update_failed:
+            # Clean up bad update
+            server["address"] = old_address
+            cb.server_modify(server["node_id"], server)
+            self.fail("Bad address modification succeeded")
+
+        return
+
+if __name__ == '__main__':
+    if 3 != len(sys.argv):
+        print "usage   : python watchlist_test.py server_url api_token"
+        print "example : python watchlist_test.py https://cb.my.org 3ab23b1bdhjj3jdjcjhh2kl\n"
+        sys.exit(0)
+
+    # instantiate a global CbApi object
+    # all unit tests will use this object
+    #
+    token = sys.argv.pop()
+    url = sys.argv.pop()
+
+    cb = CbApi(url, ssl_verify=False, token=token, client_validation_enabled=False)
+
+    # run the unit tests
+    #
+    unittest.main()

--- a/client_apis/python/src/tests/integration/team_test.py
+++ b/client_apis/python/src/tests/integration/team_test.py
@@ -1,0 +1,289 @@
+#
+# CARBON BLACK API TESTS - team
+# Copyright, Bit9, Inc 2015
+#
+
+""" These tests require CarbonBlack Enterprise Server to be installed.
+    You can run this script by passing the server URL and user API token
+    as parameters.
+"""
+
+import unittest
+import sys
+import os
+import requests
+import uuid
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")))
+
+from cbapi.cbapi import CbApi
+from helpers.testdata_gen import TestDataGen
+
+cb = None
+
+class CbApiTeamTest(unittest.TestCase):
+
+    # List teams tests
+
+    def test_list_teams(self):
+        teams = cb.team_enum()
+        self.assertIsNotNone(teams)
+        self.assertGreater(len(teams), 0)
+
+        for team in teams:
+            self._verify_retrieved_team(team)
+
+    # Get team tests
+
+    def test_get_team_bad_id(self):
+        team_id = "bad-id"
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_info(team_id)
+
+        # TODO: 2015.06.01 (dplummer): seems like it would be better to have an HTTP 400 rather than a 500
+        self.assertEqual(cm.exception.response.status_code, 500)
+
+    def test_get_team_unknown_id(self):
+        team_id = "-1"
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_info(team_id)
+
+        # TODO: 2015.06.01 (dplummer): seems like it would be better to have an HTTP 404 rather than a 500
+        self.assertEqual(cm.exception.response.status_code, 500)
+
+    def test_get_team_from_team_list(self):
+        teams = cb.team_enum()
+        self.assertIsNotNone(teams)
+        self.assertGreater(len(teams), 0)
+
+        team_id = teams[0]['id']
+        team = cb.team_info(team_id)
+        self._verify_retrieved_team(team)
+
+    # Create team tests
+
+    def test_create_team_no_name(self):
+        team_data = TestDataGen.gen_team()
+
+        team_add_params = self._convert_team_data_to_team_add_params(team_data)
+        team_add_params['team_name'] = None
+
+        # should not be able to create team with no team name
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_add_from_data(**team_add_params)
+
+        self.assertEqual(cm.exception.response.status_code, 400)
+
+    def test_create_team_name_with_special_chars(self):
+        team_data = TestDataGen.gen_team()
+
+        team_add_params = self._convert_team_data_to_team_add_params(team_data)
+        team_add_params['team_name'] = 'Test Team @' + TestDataGen.gen_uid_hex()
+
+        # should not be able to create team with a special char in name
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_add_from_data(**team_add_params)
+
+        self.assertEqual(cm.exception.response.status_code, 400)
+
+    def test_create_valid_team(self):
+        self._test_create_valid_team()
+
+    def test_create_team_duplicate_name(self):
+        first_team = self._test_create_valid_team()
+        self.assertIn('name', first_team)
+        team_name = first_team['name']
+
+        # generate second team info, but then use the same name as the first team
+        second_team_data = TestDataGen.gen_team()
+        second_team_data['name'] = team_name
+        second_team_add_params = self._convert_team_data_to_team_add_params(second_team_data)
+
+        # attempt create team with the same name
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_add_from_data(**second_team_add_params)
+
+        self.assertEqual(cm.exception.response.status_code, 409)
+
+    # Update team tests
+
+    def test_update_team_no_name(self):
+        # create the team
+        original_team = self._test_create_valid_team()
+        team_id = original_team['id']
+
+        # update the team with a new name
+        updated_team = original_team.copy()
+        updated_team['name'] = None
+
+        # should not be able to update the team to have no name
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_modify(team_id, updated_team)
+
+        self.assertEqual(cm.exception.response.status_code, 400)
+
+    def test_update_team_name_with_special_chars(self):
+        # create the team
+        original_team = self._test_create_valid_team()
+        team_id = original_team['id']
+
+        # update the team with a new name
+        updated_team = original_team.copy()
+        updated_team['name'] = 'Test Team@' + TestDataGen.gen_uid_hex()
+
+        # should not be able to update the team to include special chars
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_modify(team_id, updated_team)
+
+        self.assertEqual(cm.exception.response.status_code, 400)
+
+    def test_update_team_valid_name(self):
+        # create the team
+        original_team = self._test_create_valid_team()
+        team_id = original_team['id']
+
+        # update the team with a new name
+        updated_team = original_team.copy()
+        updated_team['name'] = 'Test Team ' + TestDataGen.gen_uid_hex()
+        team_update_result = cb.team_modify(team_id, original_team)
+        self.assertIn('result', team_update_result)
+        self.assertEqual(team_update_result['result'], "success")
+
+        # verify that the team with the ID has the updated name
+        retrieved_team = cb.team_info(team_id)
+        self._verify_retrieved_team(retrieved_team)
+        self.assertNotEqual(retrieved_team['name'], original_team['name'])
+        self.assertEqual(retrieved_team['name'], updated_team['name'])
+
+        # verify that there's no longer a team with the original name
+        self.assertNotEqual(original_team['name'], updated_team['name'])
+        self._assert_team_doesnt_exist_by_name(original_team['name'])
+
+        # verify that there's a team with the updated name
+        retrieved_team = cb.team_get_team_by_name(updated_team['name'])
+        self.assertIsNotNone(retrieved_team)
+
+    def test_update_team_duplicate_name(self):
+        # create the first team
+        first_team = self._test_create_valid_team()
+
+        # create the second team
+        original_second_team = self._test_create_valid_team()
+        second_team_id = original_second_team['id']
+
+        # update the team with a new name
+        updated_second_team = original_second_team.copy()
+        updated_second_team['name'] = first_team['name']
+
+        # should not be able to update the team to include special chars
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_modify(second_team_id, updated_second_team)
+
+        self.assertEqual(cm.exception.response.status_code, 409)
+
+        # verify that the team with the second team's ID still has the original name
+        retrieved_team = cb.team_info(second_team_id)
+        self._verify_retrieved_team(retrieved_team)
+        self.assertNotEqual(retrieved_team['name'], updated_second_team['name'])
+        self.assertEqual(retrieved_team['name'], original_second_team['name'])
+
+        # verify that there's still a team with the second team's original name
+        retrieved_team = cb.team_get_team_by_name(original_second_team['name'])
+        self.assertIsNotNone(retrieved_team)
+
+
+    # Delete team tests
+
+    def test_delete_team_bad_id(self):
+        team_id = "bad-id"
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_del(team_id)
+
+        # TODO: 2015.06.01 (dplummer): seems like it would be better to have an HTTP 400 rather than a 500
+        self.assertEqual(cm.exception.response.status_code, 500)
+
+    def test_delete_team_unknown_id(self):
+        team_id = "-1"
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_del(team_id)
+
+        # TODO: 2015.06.01 (dplummer): seems like it would be better to have an HTTP 404 rather than a 500
+        self.assertEqual(cm.exception.response.status_code, 500)
+
+    def test_delete_new_team(self):
+        # create the team
+        new_team = self._test_create_valid_team()
+        self.assertIn('id', new_team)
+        team_id = new_team['id']
+
+        # verify the team exists on the server
+        retrieved_team = cb.team_info(team_id)
+        self._verify_retrieved_team(retrieved_team)
+
+        # delete the team
+        cb.team_del(team_id)
+
+        # verify the team no longer exists on the server
+        self._assert_team_doesnt_exist(team_id)
+
+    # Test Helpers
+
+    def _test_create_valid_team(self):
+        # generate new team data
+        team_data = TestDataGen.gen_team()
+
+        # verify the team doesn't yet exist on the server
+        self._assert_team_doesnt_exist_by_name(team_data['name'])
+
+        # convert new team data into params for the add-team API
+        team_add_params = self._convert_team_data_to_team_add_params(team_data)
+
+        # create the team and verify the result
+        new_team = cb.team_add_from_data(**team_add_params)
+        self._verify_retrieved_team(new_team)
+
+        return new_team
+
+    def _assert_team_doesnt_exist(self, team_id):
+        with self.assertRaises(requests.HTTPError) as cm:
+            cb.team_info(team_id)
+
+        # TODO: 2015.06.01 (dplummer): not sure I would expect 500 as the error code
+        self.assertEqual(cm.exception.response.status_code, 500)
+
+    def _assert_team_doesnt_exist_by_name(self, team_name):
+        team = cb.team_get_team_by_name(team_name)
+        self.assertIsNone(team)
+
+    def _convert_team_data_to_team_add_params(self, team_data):
+        self.assertIn('name', team_data)
+        self.assertIn('group_access', team_data)
+
+        team_add_params = {}
+        team_add_params['team_name'] = team_data['name']
+        team_add_params['groups'] = team_data['group_access']
+        return team_add_params
+
+    def _verify_retrieved_team(self, team):
+        self.assertIsNotNone(team)
+        self.assertIn('id', team)
+        self.assertIn('name', team)
+
+if __name__ == '__main__':
+    if 3 != len(sys.argv):
+        print "usage   : python user_test.py server_url api_token"
+        print "example : python user_test.py https://cb.my.org 3ab23b1bdhjj3jdjcjhh2kl\n"
+        sys.exit(0)
+
+    # instantiate a global CbApi object
+    # all unit tests will use this object
+    #
+    token = sys.argv.pop()
+    url = sys.argv.pop()
+
+    cb = CbApi(url, ssl_verify=False, token=token, client_validation_enabled=False)
+
+    # run the unit tests
+    #
+    unittest.main()

--- a/client_apis/python/src/tests/integration/user_test.py
+++ b/client_apis/python/src/tests/integration/user_test.py
@@ -12,43 +12,16 @@ import unittest
 import sys
 import os
 import requests
-import uuid
 
 if __name__ == '__main__':
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")))
 
 from cbapi.cbapi import CbApi
+from helpers.testdata_gen import TestDataGen
 
 cb = None
 
 class CbApiUserTest(unittest.TestCase):
-    class TestDataGen:
-        @staticmethod
-        def gen_uid_hex():
-            return uuid.uuid4().hex
-
-        @classmethod
-        def gen_user(cls):
-            uid_hex = cls.gen_uid_hex()
-
-            user = {
-                'username': 'testuser' + uid_hex,
-                'first_name': 'IntegrationUser_' + uid_hex,
-                'last_name': 'TestUser',
-                'email': 'integration.testuser ' + uid_hex + '@example.com',
-                'password': 'p@ssw0rd',
-                'global_admin': False,
-                'teams': []
-            }
-            return user
-
-        @classmethod
-        def gen_global_admin(cls):
-            user = cls.gen_user()
-            user['global_admin'] = True
-
-            return user
-
     ## List user tests
 
     def test_list_users(self):
@@ -74,7 +47,7 @@ class CbApiUserTest(unittest.TestCase):
     ## Create user tests
 
     def test_create_user_no_username(self):
-        user_data = self.TestDataGen.gen_user()
+        user_data = TestDataGen.gen_user()
 
         user_add_params = self._convert_user_data_to_user_add_params(user_data)
         user_add_params['username'] = None
@@ -86,10 +59,10 @@ class CbApiUserTest(unittest.TestCase):
         self.assertEqual(cm.exception.response.status_code, 400)
 
     def test_create_user_username_with_special_chars(self):
-        user_data = self.TestDataGen.gen_user()
+        user_data = TestDataGen.gen_user()
 
         user_add_params = self._convert_user_data_to_user_add_params(user_data)
-        user_add_params['username'] = "testuser " + self.TestDataGen.gen_uid_hex()
+        user_add_params['username'] = "testuser " + TestDataGen.gen_uid_hex()
 
         # should not be able to create user with a space in the username
         with self.assertRaises(requests.HTTPError) as cm:
@@ -98,7 +71,7 @@ class CbApiUserTest(unittest.TestCase):
         self.assertEqual(cm.exception.response.status_code, 400)
 
     def test_create_user_bad_password_confirm(self):
-        user_data = self.TestDataGen.gen_user()
+        user_data = TestDataGen.gen_user()
 
         user_add_params = self._convert_user_data_to_user_add_params(user_data)
         user_add_params['confirm_password'] = "wr0ngp@ssw0rd"
@@ -121,7 +94,7 @@ class CbApiUserTest(unittest.TestCase):
         username = first_user['username']
 
         # generate second user info, but then use the same username as the first user
-        second_user_data = self.TestDataGen.gen_user()
+        second_user_data = TestDataGen.gen_user()
         second_user_data['username'] = username
         second_user_add_params = self._convert_user_data_to_user_add_params(second_user_data)
 
@@ -183,7 +156,7 @@ class CbApiUserTest(unittest.TestCase):
 
     def _test_create_valid_user(self):
         # generate new user data
-        user_data = self.TestDataGen.gen_user()
+        user_data = TestDataGen.gen_user()
 
         # verify the user doesn't yet exist on the server
         self._assert_user_doesnt_exist(user_data['username'])
@@ -205,7 +178,7 @@ class CbApiUserTest(unittest.TestCase):
 
     def _test_create_valid_global_admin(self):
         # generate new global admin user data
-        user_data = self.TestDataGen.gen_global_admin()
+        user_data = TestDataGen.gen_global_admin()
 
         # verify the user doesn't yet exist on the server
         self._assert_user_doesnt_exist(user_data['username'])


### PR DESCRIPTION
# New Methods

Implemented method to update a team
* added the `team_modify()` method to the `CbApi` class in `cbapi.py`

# New Tests

Added some basic CRUD tests for team objects in the Carbon Black Client API:
 - List teams
 - Get a team by a badly-formatted ID
 - Get a team by an unknown team ID
 - Get a team by valid team ID
 - Create team without a name
 - Create team with special chars in name
 - Create a valid team
 - Create a team with a duplicate name
 - Update a team to have no name
 - Update a team to have a name with special chars
 - Update a team to have a new valid name
 - Update a team to have a duplicate name
 - Delete a team by badly-formatted ID
 - Delete an unknown team by ID
 - Delete a new team

Note certain types of tests are not yet implemented:
 - Tests that verify authorization of different users for various actions
 - Tests that use non-default group accesses for teams

# Other
## Test Helpers: TestDataGen

Extracted the `TestDataGen` class in `user_test.py` into a new test `helpers` subpackage in a module called `testdata_gen.py` so that it can be re-used and extended in other tests
