### PR TITLE
Basic sensor API tests

### DIFF
--- a/client_apis/python/src/tests/integration/basetest.py
+++ b/client_apis/python/src/tests/integration/basetest.py
@@ -1,0 +1,35 @@
+#
+# CARBON BLACK API TESTS - watchlist
+# Copyright, Bit9, Inc 2015
+#
+
+""" These tests require CarbonBlack Enterprise Server to be installed.
+    You can run this script by passing the server URL and user API token
+    as parameters.
+"""
+
+import unittest
+import sys
+import os
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")))
+
+from cbapi.cbapi import CbApi
+
+class CbApiIntegrationTest(unittest.TestCase):
+    SERVER_URL = None
+    API_TOKEN = None
+
+    cb = None
+
+    @classmethod
+    def setUpClass(cls):
+        # instantiate a global CbApi object
+        # all unit tests will use this object
+        if cls.SERVER_URL is None:
+            cls.SERVER_URL = os.getenv('CB_SERVER_URL')
+        if cls.API_TOKEN is None:
+            cls.API_TOKEN = os.getenv('CB_API_TOKEN')
+
+        cls.cb = CbApi(cls.SERVER_URL, ssl_verify=False, token=cls.API_TOKEN, client_validation_enabled=False)

--- a/client_apis/python/src/tests/integration/basetest.py
+++ b/client_apis/python/src/tests/integration/basetest.py
@@ -1,5 +1,5 @@
 #
-# CARBON BLACK API TESTS - watchlist
+# CARBON BLACK API TESTS - basetest
 # Copyright, Bit9, Inc 2015
 #
 
@@ -25,6 +25,16 @@ class CbApiIntegrationTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        """Instantiate a CbApi object for integration tests.
+
+            Args:
+                cls: class object that is being setUp.
+            Returns:
+                None.
+            Raises:
+                TypeError: if SERVER_URL is not a valid URL or API_TOKEN is invalid
+
+        """
         # instantiate a global CbApi object
         # all unit tests will use this object
         if cls.SERVER_URL is None:

--- a/client_apis/python/src/tests/integration/sensor_test.py
+++ b/client_apis/python/src/tests/integration/sensor_test.py
@@ -1,0 +1,54 @@
+#
+# CARBON BLACK API TESTS - sensor
+# Copyright, Bit9, Inc 2015
+#
+
+""" These tests require CarbonBlack Enterprise Server to be installed.
+    You can run this script by passing the server URL and user API token
+    as parameters.
+"""
+
+import unittest
+import sys
+import os
+import requests
+
+if __name__ == '__main__':
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../")))
+
+from basetest import CbApiIntegrationTest
+
+name_prefix = "Test Sensor"
+
+class CbApiSensorTest(CbApiIntegrationTest):
+    def test_fetch_sensors_empty(self):
+        sensors = self.cb.sensors()
+        self.assertItemsEqual([], sensors)
+        return
+
+    def test_get_sensor_not_exist(self):
+        with self.assertRaises(requests.HTTPError) as cm:
+            self.cb.sensor(-1)
+        self.assertEqual(cm.exception.response.status_code, 404)
+        return
+
+    def test_statistics(self):
+        stats = self.cb.sensor_backlog()
+        self.assertIsNotNone(stats["active_sensor_count"])
+        self.assertIsNotNone(stats["sensor_count"])
+        self.assertIsNotNone(stats["num_eventlog_bytes"])
+        self.assertIsNotNone(stats["num_storefiles_bytes"])
+        return
+
+if __name__ == '__main__':
+    if 3 != len(sys.argv):
+        print "usage   : python watchlist_test.py server_url api_token"
+        print "example : python watchlist_test.py https://cb.my.org 3ab23b1bdhjj3jdjcjhh2kl\n"
+        sys.exit(0)
+
+    # set the token and server url from the arguments
+    CbApiSensorTest.API_TOKEN = sys.argv.pop()
+    CbApiSensorTest.SERVER_URL = sys.argv.pop()
+
+    # run the unit tests
+    unittest.main()


### PR DESCRIPTION
### `basetest.py`
Provides a simple base class that handles creating the `CbApi` object using either manually set values for the server URL and API token, or by reading env variables. Initialization happens in the `setUpClass` method, so that tests using this can be run via the `unittest` CLI or other harness.

Example (PowerShell):
```
$env:CB_SERVER_URL="https://127.0.0.1/";$env: CB_API_TOKEN="my_token"; python -W ignore -m unittest tests.integration.sensor_test
```
**N.B.**: You need to invoke the `unittest` CLI from the `./client_apis/python/src` directory for the modules/paths to work properly!

### `sensor_test.py`
Just a couple of quick tests that can be run against a fresh CB server that has no sensors registered yet. This should be extended to account for actually having at least one registered sensor as in a real world server set up.

Supports being run via a test harness (see description of `basetest.py` above) or invoked manually via the CLI for consistency with the existing tests.