### PR TITLE
Update license_status.py

### DIFF
--- a/client_apis/python/example/license_status.py
+++ b/client_apis/python/example/license_status.py
@@ -30,6 +30,7 @@
 #  last updated 2015-06-28 by Ben Johnson bjohnson@bit9.com
 #
 
+import sys
 import optparse
 import cbapi 
 


### PR DESCRIPTION
import sys statement is missing from script causing it to fail with the following error:

[root@cb-510-test example]# python license_status.py
Traceback (most recent call last):
  File "license_status.py", line 69, in <module>
    sys.exit(main(sys.argv[1:]))