### PR TITLE
Fix up watchlist add / edit.

### DIFF
--- a/client_apis/python/example/watchlist_add.py
+++ b/client_apis/python/example/watchlist_add.py
@@ -46,7 +46,7 @@ def build_cli_parser():
     parser.add_option("-n", "--no-ssl-verify", action="store_false", default=True, dest="ssl_verify",
                       help="Do not verify server SSL certificate.")
     parser.add_option("-q", "--query", action="store", default=None, dest="query",
-                      help="Watchlist query string, start with q=  e.g. q=process_name:notepad.exe")
+                      help="Watchlist query string, e.g. process_name:notepad.exe")
     parser.add_option("-t", "--type", action="store", default=None, dest="type",
                       help="Watchlist type 'events' or 'modules'")
     parser.add_option("-N", "--name", action="store", default=None, dest="name",
@@ -88,10 +88,6 @@ def main(argv):
     if opts.type != "events" and opts.type != "modules":
         print "Watchlist type must be one of 'events' or 'modules'"
         sys.exit(-1)
-    if not opts.query.startswith("q="):
-        print "Query must begin with q="
-        print opts.query
-        sys.exit(-1)
 
     # build a cbapi object
     #
@@ -101,7 +97,12 @@ def main(argv):
     # for the purposes of this test script, hardcode the watchlist type, name, and query string
     #
     print "-> Adding watchlist..."
-    watchlist = cb.watchlist_add(opts.type, opts.name, opts.query, id=opts.id, readonly=opts.readonly)
+    watchlist = cb.watchlist_add(
+        opts.type,
+        opts.name,
+        opts.query,
+        id=opts.id,
+        readonly=opts.readonly)
     print "-> Watchlist added [id=%s]" % (watchlist['id'])
 
     # get record describing this watchlist  

--- a/client_apis/python/example/watchlist_add_edit_del.py
+++ b/client_apis/python/example/watchlist_add_edit_del.py
@@ -80,7 +80,10 @@ def main(argv):
     # for the purposes of this test script, hardcode the watchlist type, name, and query string
     #
     print "-> Adding watchlist..."
-    watchlist = cb.watchlist_add('events', 'test watchlist', 'q=process_name:notepad.exe')
+    watchlist = cb.watchlist_add(
+        'events',
+        'test watchlist',
+        'process_name:notepad.exe')
     print "-> Watchlist added [id=%s]" % (watchlist['id'])
 
     # get record describing this watchlist  
@@ -93,7 +96,7 @@ def main(argv):
     # edit the search query of the just-added watchlist
     #
     print "-> Modifying the watchlist query..."
-    watchlist['search_query'] = 'q=process_name:calc.exe'
+    watchlist['search_query'] = 'process_name:calc.exe'
     cb.watchlist_modify(watchlist['id'], watchlist)
     print "-> Watchlist modified" 
 

--- a/client_apis/python/example/watchlist_edit.py
+++ b/client_apis/python/example/watchlist_edit.py
@@ -48,7 +48,7 @@ def build_cli_parser():
     parser.add_option("-i", "--id", action="store", default=None, dest="id",
                       help="Watchlist ID to modify")
     parser.add_option("-q", "--query", action="store", default=None, dest="query",
-                      help="New search query")
+                      help="New search query, e.g. process_name:notepad.exe")
     return parser
 
 def watchlist_output(watchlist):
@@ -72,14 +72,6 @@ def main(argv):
     if not opts.url or not opts.token or not opts.id or not opts.query:
         print "Missing required param; run with --help for usage"
         sys.exit(-1)
-
-    # ensure the query string is minimally valid
-    #
-    if not opts.query.startswith("q="):
-        print "Query must start with 'q='.  Examples;"
-        print "  q=process_name:notepad.exe"
-        print "  q=-modload:kernel32.dll"
-        sys.exit(0)
 
     # build a cbapi object
     #

--- a/client_apis/python/src/cbapi/cbapi.py
+++ b/client_apis/python/src/cbapi/cbapi.py
@@ -7,6 +7,7 @@
 import json
 import time
 import requests
+import urllib
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager
 
@@ -369,13 +370,12 @@ class CbApi(object):
             if "events" != type and "modules" != type:
                 raise ValueError("type must be one of events or modules")
 
-            # ensure that the query begins with q=
-            if not "q=" in search_query:
-                raise ValueError("watchlist queries must be of the form: cb.urlver=1&q=<query>")
+            # urlencode the query
+            search_query = urllib.quote(search_query)
 
-            # ensure that a cb url version is included
-            if "cb.urlver" not in search_query:
-                search_query = "cb.urlver=1&" + search_query
+            # ensure that it starts with the proper url parameters
+            if not search_query.startswith("cb.urlver=1&q="):
+                search_query = "cb.urlver=1&q=" + search_query
 
             # ensure that the query itself is properly encoded
             for kvpair in search_query.split('&'):
@@ -427,7 +427,10 @@ class CbApi(object):
         updates a watchlist
         """
         url = "%s/api/v1/watchlist/%s" % (self.server, id)
-
+        watchlist['search_query'] = urllib.quote(watchlist['search_query'])
+        # ensure that it starts with the proper url parameters
+        if not watchlist['search_query'].startswith("cb.urlver=1&q="):
+            watchlist['search_query'] = "cb.urlver=1&q=" + watchlist['search_query']
         r = self.cbapi_put(url, data=json.dumps(watchlist))
         r.raise_for_status()
 

--- a/client_apis/python/src/cbapi/cbapi.py
+++ b/client_apis/python/src/cbapi/cbapi.py
@@ -383,7 +383,6 @@ class CbApi(object):
 
             # ensure that the query itself is properly encoded
             for kvpair in search_query.split('&'):
-                print kvpair
                 if len(kvpair.split('=')) != 2:
                     continue
                 if kvpair.split('=')[0] != 'q':

--- a/client_apis/python/src/cbapi/cbapi.py
+++ b/client_apis/python/src/cbapi/cbapi.py
@@ -375,7 +375,7 @@ class CbApi(object):
 
             # be backwards compatable with people still submitting
             # queries with q= at the beginning and just add cb.urlver=1&
-            if search_query.startswith("q=") and "cb.urlver" not in search_query::
+            if search_query.startswith("q=") and "cb.urlver" not in search_query:
                 search_query = "cb.urlver=1&" + search_query
             # ensure that it starts with the proper url parameters
             elif not search_query.startswith("cb.urlver=1&q="):

--- a/client_apis/python/src/cbapi/cbapi.py
+++ b/client_apis/python/src/cbapi/cbapi.py
@@ -373,8 +373,12 @@ class CbApi(object):
             # urlencode the query
             search_query = urllib.quote(search_query)
 
+            # be backwards compatable with people still submitting
+            # queries with q= at the beginning and just add cb.urlver=1&
+            if search_query.startswith("q=") and "cb.urlver" not in search_query::
+                search_query = "cb.urlver=1&" + search_query
             # ensure that it starts with the proper url parameters
-            if not search_query.startswith("cb.urlver=1&q="):
+            elif not search_query.startswith("cb.urlver=1&q="):
                 search_query = "cb.urlver=1&q=" + search_query
 
             # ensure that the query itself is properly encoded


### PR DESCRIPTION
It's required that search queries be urlencoded (https://github.com/carbonblack/cbapi/blob/master/client_apis/python/src/cbapi/cbapi.py#L391-L393) and because of that the watchlist add / edit example scripts were failing. 

Also, I believe that it should not be on the user to add "q=" and urlencode it on their side, this should be taken care of by cbapi. This diff make that so, and also accounts for people still submitting queries with "q=" at the beginning.